### PR TITLE
Current-User-Profile-Bug

### DIFF
--- a/components/form-elements/input.js
+++ b/components/form-elements/input.js
@@ -1,4 +1,13 @@
-export function Input({ id, type="text", placeholder="", refEl=undefined, label=undefined, onChangeEvent, addlClass="", children }) {
+export function Input({
+  id,
+  type = "text",
+  placeholder = "",
+  refEl = undefined,
+  label = undefined,
+  onChangeEvent,
+  addlClass = "",
+  children,
+}) {
   return (
     <div className={`field ${addlClass}`}>
       {label && <label className="label">{label}</label>}

--- a/data/auth.js
+++ b/data/auth.js
@@ -1,29 +1,29 @@
 import { fetchWithResponse } from "./fetcher"
 
 export function login(user) {
-  return fetchWithResponse('login', {
-    method: 'POST',
+  return fetchWithResponse("login", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(user)
+    body: JSON.stringify(user),
   })
 }
 
 export function register(user) {
-  return fetchWithResponse('register', {
-    method: 'POST',
+  return fetchWithResponse("register", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(user)
+    body: JSON.stringify(user),
   })
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse("profile", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-    }
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bangazon-client",
+  "name": "bangazon-client-chupacabra-t2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This solves the `404 not found` catchError when user would navigate to the "profile" link in the browser

**Changes**

- adjusted the URL in `/data/auth.js` to be consistent and accurate with the URL route in the Bangazon API

**Testing**

1. Make sure that you are in the Bangazon API in VS Code and start your debugger
2. In your browser, make sure that your dev tools are open
3. log in as one of the users, for example: username: jisie, password: Admin8*
4. _When you log in, you will get a `500 Internal Server Error` because of an issue with /products-- this is a different bug, please disregard for this test_
5. Navigate to the "Profile" link -- there should not be any "profile" errors showing in your console.
6. Please click on the "application" tab in your dev tools and confirm that the token you have used to sign in (it will be `9ba45f09651c5b0c404f37a2d2572c026c146688` if you logged in under my example) is showing in the key
         _Please note, there are places for information that are empty, these are addressed in later feature tickets_
8. Log out, and please log in as another user, for example: steve, password: Admin8* and confirm that your token key has changed to match that user

**Related Issues**

- Fixes issue ticket #32 