### PR TITLE
Jv bugfix - past orders not displaying correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bangazon-client",
+  "name": "bangazon-client-chupacabra-t2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -1,35 +1,42 @@
-import { useEffect, useState } from 'react'
-import CardLayout from '../components/card-layout'
-import Layout from '../components/layout'
-import Navbar from '../components/navbar'
-import Table from '../components/table'
-import { getOrders } from '../data/orders'
+import { useEffect, useState } from "react"
+import CardLayout from "../components/card-layout"
+import Layout from "../components/layout"
+import Navbar from "../components/navbar"
+import Table from "../components/table"
+import { getOrders } from "../data/orders"
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
-  const headers = ['Order Date', 'Total', 'Payment Method']
+  const headers = ["Order Date", "Total", "Payment Method"]
 
   useEffect(() => {
-    getOrders().then(ordersData => {
+    getOrders().then((ordersData) => {
       if (ordersData) {
         setOrders(ordersData)
       }
     })
   }, [])
 
+  // Function to calculate total price of line items for an order
+  const calculateTotal = (lineItems) => {
+    let totalPrice = 0
+    lineItems.forEach((item) => {
+      totalPrice += item.product.price
+    })
+    return totalPrice.toFixed(2) // Adjust to 2 decimal places
+  }
+
   return (
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {
-            orders.map((order) => (
-              <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
-              </tr>
-            ))
-          }
+          {orders.map((order) => (
+            <tr key={order.id}>
+              <td>{order.created_date}</td>
+              <td>${calculateTotal(order.lineitems)}</td>
+              <td>{order.payment?.merchant_name}</td>
+            </tr>
+          ))}
         </Table>
         <></>
       </CardLayout>


### PR DESCRIPTION
This solves the My Orders tab not correctly displaying the Order Date, Total, and Payment. 

Changes

- adjusted the `pages/my-orders.js` to correctly get the properties of the order object. 

Testing

- make sure API is running on backend
- in your browser login as `joe` 
- click the `My Orders` tab in the drop down
- verify that there are `order date` , `totals`, and `payment method` on the page. Payment type will be blank if it is null and the total will be zero if there are no line items for an order. 

Resolves bug ticket #2 