### PR TITLE
Jv bugfix - cart resource has duplicate line items

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from "./fetcher"
 
 export function getCart() {
-  return fetchWithResponse("cårt", {
+  return fetchWithResponse("cart", {
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
     },


### PR DESCRIPTION
Changes:
- changed a typo in `data/orders.js` that allows for items in the cart to display. 
Testing:
- Verify that your Python debugger is up to date and running.
- Login in as a user and navigate to `Cart`
- Verify that items are viewable in the Cart page like in the image. 

![Cart in Bangazon](https://github.com/NSS-Day-Cohort-68/bangazon-client-chupacabra-t2/assets/150074264/da46dbf2-2702-42c8-9765-8709303d3ba1)

